### PR TITLE
Json出力の確認ダイアログの追加 closes #88

### DIFF
--- a/fanbox-downloader.ts
+++ b/fanbox-downloader.ts
@@ -14,6 +14,8 @@ class DownloadManage {
 
 	public isIgnoreFree = false;
 
+	public isExportJson = false;
+
 	private fees: number[] = [];
 
 	private tags: string[] = [];
@@ -160,6 +162,7 @@ async function getItemsById(downloadManage: DownloadManage) {
 			downloadManage.setLimit(limit);
 		}
 	}
+	downloadManage.isExportJson = confirm('info.txtの代わりに、info.jsonを出力する？');
 	let nextUrl:
 		| string
 		| null = `https://api.fanbox.cc/post.listCreator?creatorId=${downloadManage.userId}&limit=100`;
@@ -337,7 +340,12 @@ function addByPostInfo(downloadManage: DownloadManage, postInfo: PostInfo | unde
 			console.log(`不明なタイプ\n${postInfo.type}@${postInfo.id}`);
 			break;
 	}
-	postObject.setInfo(informationTextBase + informationText);
+	if (downloadManage.isExportJson) {
+		postInfo.txt = informationText;
+		postObject.setInfo(JSON.stringify(postInfo, null, 0));
+	} else {
+		postObject.setInfo(informationTextBase + informationText);
+	}
 	downloadManage.decrementLimit();
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -35,6 +35,7 @@ type PostInfo = {
 	id: string;
 	coverImageUrl: string | null;
 	excerpt: string;
+	txt: string;
 	tags: string[];
 	// DateはJSON.parseで文字列扱い
 	publishedDatetime: string;


### PR DESCRIPTION
-  PostInfoにtxtを追加しました
- DownloadManageにisExportJsonを追加しました。
- getItemsByIdにJson出力の確認ダイアログを追加しました。
- addByPostInfoのsetInfoを、DownloadManage.isExportJsonを用いて、txtで出力するかjson形式で出力するかを追加しました。

TypeScriptをあまり触ったことがないので、もし変更に過不足や間違いがありましたらすみません。
何卒よろしくお願いします！